### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ primitive operations (like concatenation, folding, etc).
 * Logical operators: `&& || !`
 * Bitwise operators: `& | << >> ~ ^`
 * Unary operators: `- +`
-* Comparision operators: `< > <= >= == != is`
+* Comparison operators: `< > <= >= == != is`
 
 Objects in GML can be equal or the same. Objects are considered the same
 when they refer to the same slot in the enviroment. Sameness is compared


### PR DESCRIPTION
@graphitemaster, I've corrected a typographical error in the documentation of the [gml](https://github.com/graphitemaster/gml) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
